### PR TITLE
Ranking any note type: support for NIP-20 & NIP-23 

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -22,12 +22,12 @@ var (
 	weightZapsGlobal             float64
 	weightRecency                float64
 	viralThreshold               float64
-	viralPostDampening           float64
+	viralNoteDampening           float64
 	decayRate                    float64
 )
 
 type CachedFeeds struct {
-	Feeds           [][]FeedPost // Multiple feed variants
+	Feeds           map[int][][]FeedNote // Multiple feed variants
 	Timestamp       time.Time
 	LastServedIndex int // Index of the last served feed variant
 }
@@ -36,173 +36,211 @@ var userFeedCache sync.Map
 
 const feedCacheDuration = 5 * time.Minute
 const numFeedVariants = 5   // Number of different feed variants to generate
-const variantFeedSize = 100 // Each variant feed size (fixed to 100 posts)
+const variantFeedSize = 100 // Each variant feed size (fixed to 100 notes)
 
 var pendingRequests = make(map[string]chan struct{})
 var pendingRequestsMutex sync.Mutex
 
-func GetUserFeed(ctx context.Context, userID string, limit int) ([]nostr.Event, error) {
+func getCacheKey(userID string, kind int) string {
+	return fmt.Sprintf("%s_kind_%d", userID, kind)
+}
+
+func GetUserFeed(ctx context.Context, userID string, limit, kind int) ([]nostr.Event, error) {
 	now := time.Now()
 
-	// Check if the feed variants are already cached
-	if cached, ok := getCachedUserFeeds(userID); ok && now.Sub(cached.Timestamp) < feedCacheDuration {
-		log.Println("Returning cached feed for user:", userID)
-		return serveSequentialFeedResult(userID, cached, limit), nil
+	if cached, ok := getCachedUserFeeds(userID, kind); ok && now.Sub(cached.Timestamp) < feedCacheDuration {
+		log.Println("Returning cached feed for user:", userID, "kind:", kind)
+		return serveSequentialFeedResult(userID, kind, cached, limit), nil
 	}
 
-	// Check if feed generation is already pending
 	pendingRequestsMutex.Lock()
-	if pending, exists := pendingRequests[userID]; exists {
-		log.Println("Waiting for existing feed generation for user:", userID)
+	cacheKey := getCacheKey(userID, kind)
+	if pending, exists := pendingRequests[cacheKey]; exists {
+		log.Println("Waiting for existing feed generation for user:", userID, "kind:", kind)
 		pendingRequestsMutex.Unlock()
 		<-pending
-		if cached, ok := getCachedUserFeeds(userID); ok && now.Sub(cached.Timestamp) < feedCacheDuration {
-			return serveSequentialFeedResult(userID, cached, limit), nil
+		if cached, ok := getCachedUserFeeds(userID, kind); ok && now.Sub(cached.Timestamp) < feedCacheDuration {
+			return serveSequentialFeedResult(userID, kind, cached, limit), nil
 		}
 		return nil, fmt.Errorf("feed generation failed after waiting for cache")
 	}
 
-	// Set up a new pending request for this user
 	pending := make(chan struct{})
-	pendingRequests[userID] = pending
+	pendingRequests[cacheKey] = pending
 	pendingRequestsMutex.Unlock()
 
 	defer func() {
 		pendingRequestsMutex.Lock()
 		close(pending)
-		delete(pendingRequests, userID)
+		delete(pendingRequests, cacheKey)
 		pendingRequestsMutex.Unlock()
 	}()
 
-	// Generate the feed variants
-	log.Println("No cache or pending request found, generating feed variants for user:", userID)
-	authorFeed, err := repository.GetUserFeedByAuthors(ctx, userID, variantFeedSize*numFeedVariants)
+	log.Println("No cache or pending request found, generating feed variants for user:", userID, "kind:", kind)
+	authorFeed, err := repository.GetUserFeedByAuthors(ctx, userID, variantFeedSize*numFeedVariants, kind)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get viral posts from cache
-	viralPostCacheMutex.Lock()
-	viralFeed := viralPostCache.Posts
-	viralPostCacheMutex.Unlock()
+	viralNoteCacheMutex.Lock()
+	viralFeed := viralNoteCache.notes
+	viralNoteCacheMutex.Unlock()
 
-	// Generate multiple feed variants with a fixed size of 100 posts each, incorporating viral posts
-	feedVariants := generateFeedVariants(authorFeed, viralFeed, variantFeedSize)
+	kinds := []int{kind}
+	feedVariants := generateFeedVariants(authorFeed, viralFeed, variantFeedSize, kinds)
 
-	// Cache the generated feed variants with LastServedIndex initialized to -1
 	cachedFeeds := CachedFeeds{
 		Feeds:           feedVariants,
 		Timestamp:       now,
 		LastServedIndex: -1,
 	}
-	userFeedCache.Store(userID, cachedFeeds)
+	storeCachedUserFeeds(userID, kind, cachedFeeds)
 
-	return serveSequentialFeedResult(userID, cachedFeeds, limit), nil
+	return serveSequentialFeedResult(userID, kind, cachedFeeds, limit), nil
 }
 
-func getCachedUserFeeds(userID string) (CachedFeeds, bool) {
-	if cached, ok := userFeedCache.Load(userID); ok {
+func getCachedUserFeeds(userID string, kind int) (CachedFeeds, bool) {
+	cacheKey := getCacheKey(userID, kind)
+	if cached, ok := userFeedCache.Load(cacheKey); ok {
 		return cached.(CachedFeeds), true
 	}
 	return CachedFeeds{}, false
 }
 
-func serveSequentialFeedResult(userID string, cachedFeeds CachedFeeds, limit int) []nostr.Event {
-	// Determine the next feed variant to serve
-	nextIndex := (cachedFeeds.LastServedIndex + 1) % len(cachedFeeds.Feeds)
-	selectedFeed := cachedFeeds.Feeds[nextIndex]
+func storeCachedUserFeeds(userID string, kind int, cachedFeeds CachedFeeds) {
+	cacheKey := getCacheKey(userID, kind)
+	userFeedCache.Store(cacheKey, cachedFeeds)
+}
 
-	// Update LastServedIndex in the cache
+func serveSequentialFeedResult(userID string, kind int, cachedFeeds CachedFeeds, limit int) []nostr.Event {
+	// Check if there are feed variants for the given kind
+	feedVariants, ok := cachedFeeds.Feeds[kind]
+	if !ok || len(feedVariants) == 0 {
+		log.Printf("No feed variants available for user: %s, kind: %d", userID, kind)
+		return nil
+	}
+
+	// Determine the next feed variant to serve
+	nextIndex := (cachedFeeds.LastServedIndex + 1) % len(feedVariants)
+	selectedFeed := feedVariants[nextIndex]
+
+	// Update LastServedIndex in the cache for the given kind
 	cachedFeeds.LastServedIndex = nextIndex
-	userFeedCache.Store(userID, cachedFeeds)
+	storeCachedUserFeeds(userID, kind, cachedFeeds)
 
 	// Convert the selected feed to nostr.Event results, applying the limit
 	var result []nostr.Event
-	for i, feedPost := range selectedFeed {
+	for i, feedNote := range selectedFeed {
 		if i >= limit {
 			break
 		}
-		result = append(result, feedPost.Event)
+		result = append(result, feedNote.Event) // Ensure FeedNote has an Event field
 	}
-	log.Printf("Serving feed variant %d with %d posts (limit %d) for user: %s", nextIndex, len(result), limit, userID)
+
+	log.Printf("Serving feed variant %d with %d notes (limit %d, kind %d) for user: %s", nextIndex, len(result), limit, kind, userID)
 	return result
 }
 
-func generateFeedVariants(authorFeed, viralFeed []FeedPost, variantSize int) [][]FeedPost {
-	// Group posts by author
-	authorPosts := make(map[string][]FeedPost)
-	for _, post := range authorFeed {
-		authorID := post.Event.PubKey
-		authorPosts[authorID] = append(authorPosts[authorID], post)
+func generateFeedVariants(authorFeed, viralFeed []FeedNote, variantSize int, kinds []int) map[int][][]FeedNote {
+	// Create a map to store feed variants for each kind
+	feedVariantsByKind := make(map[int][][]FeedNote)
+
+	for _, kind := range kinds {
+		// Filter author feed and viral feed by kind
+		var filteredAuthorFeed []FeedNote
+		var filteredViralFeed []FeedNote
+
+		for _, note := range authorFeed {
+			if note.Event.Kind == kind {
+				filteredAuthorFeed = append(filteredAuthorFeed, note)
+			}
+		}
+
+		for _, note := range viralFeed {
+			if note.Event.Kind == kind {
+				filteredViralFeed = append(filteredViralFeed, note)
+			}
+		}
+
+		// Group notes by author
+		authorNotes := make(map[string][]FeedNote)
+		for _, note := range filteredAuthorFeed {
+			authorID := note.Event.PubKey
+			authorNotes[authorID] = append(authorNotes[authorID], note)
+		}
+
+		// Generate multiple feed variants with one note per author in each
+		var feedVariants [][]FeedNote
+		for i := 0; i < numFeedVariants; i++ {
+			var feed []FeedNote
+			usedAuthors := make(map[string]bool)
+
+			// Add author notes for the variant
+			for _, notes := range authorNotes {
+				if len(notes) > i {
+					// Use a different note from this author in each variant, if available
+					feed = append(feed, notes[i])
+				} else {
+					// If not enough unique notes, wrap around to use existing ones
+					feed = append(feed, notes[i%len(notes)])
+				}
+				usedAuthors[notes[0].Event.PubKey] = true
+			}
+
+			// Add viral notes, ensuring no duplicate authors
+			for _, viralNote := range filteredViralFeed {
+				if len(feed) >= variantSize {
+					break
+				}
+				authorID := viralNote.Event.PubKey
+				if !usedAuthors[authorID] {
+					feed = append(feed, viralNote)
+					usedAuthors[authorID] = true
+				}
+			}
+
+			// Sort each feed by score in descending order and truncate to variant size
+			sort.Slice(feed, func(i, j int) bool {
+				return feed[i].Score > feed[j].Score
+			})
+			if len(feed) > variantSize {
+				feed = feed[:variantSize]
+			}
+			feedVariants = append(feedVariants, feed)
+		}
+
+		// Store feed variants for the current kind
+		feedVariantsByKind[kind] = feedVariants
 	}
 
-	// Generate multiple feed variants with one post per author in each
-	var feedVariants [][]FeedPost
-	for i := 0; i < numFeedVariants; i++ {
-		var feed []FeedPost
-		usedAuthors := make(map[string]bool)
-
-		// Add author posts for the variant
-		for _, posts := range authorPosts {
-			if len(posts) > i {
-				// Use a different post from this author in each variant, if available
-				feed = append(feed, posts[i])
-			} else {
-				// If not enough unique posts, wrap around to use existing ones
-				feed = append(feed, posts[i%len(posts)])
-			}
-			usedAuthors[posts[0].Event.PubKey] = true
-		}
-
-		// Add viral posts, ensuring no duplicate authors
-		for _, viralPost := range viralFeed {
-			if len(feed) >= variantSize {
-				break
-			}
-			authorID := viralPost.Event.PubKey
-			if !usedAuthors[authorID] {
-				feed = append(feed, viralPost)
-				usedAuthors[authorID] = true
-			}
-		}
-
-		// Sort each feed by score in descending order and truncate to variant size
-		sort.Slice(feed, func(i, j int) bool {
-			return feed[i].Score > feed[j].Score
-		})
-		if len(feed) > variantSize {
-			feed = feed[:variantSize]
-		}
-		feedVariants = append(feedVariants, feed)
-	}
-	log.Printf("Generated %d feed variants for user, each with %d posts, including viral posts", numFeedVariants, variantSize)
-	return feedVariants
+	log.Printf("Generated feed variants for kinds %v, each with %d notes per variant", kinds, variantSize)
+	return feedVariantsByKind
 }
-
-func (r *NostrRepository) GetUserFeedByAuthors(ctx context.Context, userID string, limit int) ([]FeedPost, error) {
+func (r *NostrRepository) GetUserFeedByAuthors(ctx context.Context, userID string, limit, kind int) ([]FeedNote, error) {
 	authorInteractions, err := r.fetchTopInteractedAuthors(userID)
 	if err != nil {
 		return nil, err
 	}
 
-	posts, err := r.fetchPostsFromAuthors(authorInteractions)
+	notes, err := r.fetchNotesFromAuthors(authorInteractions, kind)
 	if err != nil {
 		return nil, err
 	}
 
-	var feedPosts []FeedPost
-	for _, post := range posts {
-		interactionCount := getInteractionCountForAuthor(post.Event.PubKey, authorInteractions)
-		score := r.calculateAuthorPostScore(post, interactionCount)
-		feedPosts = append(feedPosts, FeedPost{Event: post.Event, Score: score})
+	fmt.Println("Fetched notes from authors:", len(notes))
+	var FeedNotes []FeedNote
+	for _, note := range notes {
+		interactionCount := getInteractionCountForAuthor(note.Event.PubKey, authorInteractions)
+		score := r.calculateAuthorNoteScore(note, interactionCount)
+		FeedNotes = append(FeedNotes, FeedNote{Event: note.Event, Score: score})
 	}
 
 	// Sort all posts by score in descending order initially
-	sort.Slice(feedPosts, func(i, j int) bool {
-		return feedPosts[i].Score > feedPosts[j].Score
+	sort.Slice(FeedNotes, func(i, j int) bool {
+		return FeedNotes[i].Score > FeedNotes[j].Score
 	})
 
-	return feedPosts, nil
+	return FeedNotes, nil
 }
 
 func getInteractionCountForAuthor(authorID string, interactions []AuthorInteraction) int {
@@ -214,7 +252,7 @@ func getInteractionCountForAuthor(authorID string, interactions []AuthorInteract
 	return 0
 }
 
-func (r *NostrRepository) calculateAuthorPostScore(event EventWithMeta, interactionCount int) float64 {
+func (r *NostrRepository) calculateAuthorNoteScore(event EventWithMeta, interactionCount int) float64 {
 	recencyFactor := calculateRecencyFactor(event.CreatedAt)
 
 	score := float64(event.GlobalCommentsCount)*weightCommentsGlobal +

--- a/import.go
+++ b/import.go
@@ -12,12 +12,12 @@ const layout = "2006-01-02"
 
 func importNotes(kind int) {
 	ctx := context.Background()
-	startDate := time.Now().Add(-30 * 24 * time.Hour)
+	startDate := time.Now().Add(-5 * 24 * time.Hour)
 	startTime, _ := time.Parse(layout, startDate.Format(layout))
 	endTime := startTime.Add(24 * time.Hour)
 
 	for {
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 
 		startTimestamp := nostr.Timestamp(startTime.Unix())

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -1,6 +1,7 @@
-CREATE TABLE IF NOT EXISTS posts (
+CREATE TABLE IF NOT EXISTS notes (
     id TEXT PRIMARY KEY,
     author_id TEXT,
+    kind INTEGER,
     content TEXT,
     raw_json JSONB, 
     created_at TIMESTAMP
@@ -8,14 +9,14 @@ CREATE TABLE IF NOT EXISTS posts (
 
 CREATE TABLE IF NOT EXISTS reactions (
     id TEXT PRIMARY KEY,
-    post_id TEXT REFERENCES posts(id),
+    note_id TEXT REFERENCES notes(id),
     reactor_id TEXT,
     created_at TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS zaps (
     id TEXT PRIMARY KEY,
-    post_id TEXT REFERENCES posts(id),
+    note_id TEXT REFERENCES notes(id),
     zapper_id TEXT,
     amount BIGINT,
     created_at TIMESTAMP
@@ -23,7 +24,7 @@ CREATE TABLE IF NOT EXISTS zaps (
 
 CREATE TABLE IF NOT EXISTS comments (
     id TEXT PRIMARY KEY,
-    post_id TEXT REFERENCES posts(id),
+    note_id TEXT REFERENCES notes(id),
     commenter_id TEXT,
     content TEXT,
     created_at TIMESTAMP
@@ -34,19 +35,20 @@ CREATE TABLE IF NOT EXISTS follows (
     follow_id TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_posts_author_id ON posts(author_id);
-CREATE INDEX IF NOT EXISTS idx_posts_created_at ON posts(created_at);
+CREATE INDEX IF NOT EXISTS idx_notes_author_id ON notes(author_id);
+CREATE INDEX IF NOT EXISTS idx_notes_kind ON notes(kind);
+CREATE INDEX IF NOT EXISTS idx_notes_created_at ON notes(created_at);
 
-CREATE INDEX IF NOT EXISTS idx_reactions_post_id ON reactions(post_id);
+CREATE INDEX IF NOT EXISTS idx_reactions_note_id ON reactions(note_id);
 CREATE INDEX IF NOT EXISTS idx_reactions_reactor_id ON reactions(reactor_id);
 CREATE INDEX IF NOT EXISTS idx_reactions_created_at ON reactions(created_at);
 
-CREATE INDEX IF NOT EXISTS idx_zaps_post_id ON zaps(post_id);
+CREATE INDEX IF NOT EXISTS idx_zaps_note_id ON zaps(note_id);
 CREATE INDEX IF NOT EXISTS idx_zaps_zapper_id ON zaps(zapper_id);
 CREATE INDEX IF NOT EXISTS idx_zaps_amount ON zaps(amount);
 CREATE INDEX IF NOT EXISTS idx_zaps_created_at ON zaps(created_at);
 
-CREATE INDEX IF NOT EXISTS idx_comments_post_id ON comments(post_id);
+CREATE INDEX IF NOT EXISTS idx_comments_note_id ON comments(note_id);
 CREATE INDEX IF NOT EXISTS idx_comments_commenter_id ON comments(commenter_id);
 CREATE INDEX IF NOT EXISTS idx_comments_created_at ON comments(created_at);
 


### PR DESCRIPTION
- No longer hard codes `posts` as an object type, now uses `notes`
- Currently subscribing to kinds `30023`, `20` and `1` notes to rank (more can be added later easily)
- Creates cached feed variants by kind now, so users can get a rank ordered list of notes of a specific kind